### PR TITLE
[HSLink-Pro] fix delay issues for uart rx to usb

### DIFF
--- a/projects/HSLink-Pro/src/main.c
+++ b/projects/HSLink-Pro/src/main.c
@@ -8,6 +8,7 @@
 #include "projects/HSLink-Pro/common/HSLink_Pro_expansion.h"
 
 extern void uartx_preinit(void);
+extern void usb2uart_handler (void);
 
 char serial_number[32];
 
@@ -61,6 +62,7 @@ int main(void)
     while (1) {
         chry_dap_handle();
         chry_dap_usb2uart_handle();
+        usb2uart_handler();
         HSP_Loop();
     }
 }


### PR DESCRIPTION
### 问题描述
在`UART`连续`RX`的时候，由于`ringbuffer`的写入是在`IDLE`中断或者`DMA`完成中断执行的，导致连续的数据接收会延迟给到`USB`

### 解决方案
在`main`中循环检查`DMA`是否存在数据，存在则将数据写入到`ringbuffer`推送至`USB`