### PR TITLE
hslink: fix: download reset mode do not clear

### DIFF
--- a/projects/HSLink-Pro/src/HID_COMM/hid_comm.cpp
+++ b/projects/HSLink-Pro/src/HID_COMM/hid_comm.cpp
@@ -229,13 +229,13 @@ static void settings(Document &root, char *res) {
     HSLink_Setting.power.power_on = power["power_on"].GetBool();
     HSLink_Setting.power.port_on = power["port_on"].GetBool();
 
+    HSLink_Setting.reset = 0;
     for (auto &reset: data["reset"].GetArray()) {
-        if (!SETTING_GET_RESET_MODE(HSLink_Setting.reset, RESET_NRST) && strcmp(reset.GetString(), "nrst") == 0) {
+        if (strcmp(reset.GetString(), "nrst") == 0) {
             SETTING_SET_RESET_MODE(HSLink_Setting.reset, RESET_NRST);
-        } else if (!SETTING_GET_RESET_MODE(HSLink_Setting.reset, RESET_POR) && strcmp(reset.GetString(), "por") == 0) {
+        } else if (strcmp(reset.GetString(), "por") == 0) {
             SETTING_SET_RESET_MODE(HSLink_Setting.reset, RESET_POR);
-        } else if (!SETTING_GET_RESET_MODE(HSLink_Setting.reset, RESET_ARM_SWD_SOFT) && strcmp(
-                reset.GetString(), "arm_swd_soft") == 0) {
+        } else if (strcmp(reset.GetString(), "arm_swd_soft") == 0) {
             SETTING_SET_RESET_MODE(HSLink_Setting.reset, RESET_ARM_SWD_SOFT);
         }
     }

--- a/projects/HSLink-Pro/src/setting.cpp
+++ b/projects/HSLink-Pro/src/setting.cpp
@@ -119,13 +119,13 @@ static void parse_settings(std::string_view json) {
     HSLink_Setting.power.power_on = power["power_on"].GetBool();
     HSLink_Setting.power.port_on = power["port_on"].GetBool();
 
+    HSLink_Setting.reset = 0;
     for (auto &reset: root["reset"].GetArray()) {
-        if (!SETTING_GET_RESET_MODE(HSLink_Setting.reset, RESET_NRST) && strcmp(reset.GetString(), "nrst") == 0) {
+        if (strcmp(reset.GetString(), "nrst") == 0) {
             SETTING_SET_RESET_MODE(HSLink_Setting.reset, RESET_NRST);
-        } else if (!SETTING_GET_RESET_MODE(HSLink_Setting.reset, RESET_POR) && strcmp(reset.GetString(), "por") == 0) {
+        } else if (strcmp(reset.GetString(), "por") == 0) {
             SETTING_SET_RESET_MODE(HSLink_Setting.reset, RESET_POR);
-        } else if (!SETTING_GET_RESET_MODE(HSLink_Setting.reset, RESET_ARM_SWD_SOFT) && strcmp(
-                                                                                                reset.GetString(), "arm_swd_soft") == 0) {
+        } else if (strcmp(reset.GetString(), "arm_swd_soft") == 0) {
             SETTING_SET_RESET_MODE(HSLink_Setting.reset, RESET_ARM_SWD_SOFT);
         }
     }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Streamlined reset configuration by initializing the reset state before processing new input.
  - Simplified the logic for applying reset options, resulting in a more consistent and reliable experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->