### PR TITLE
fix: settings read from flash

### DIFF
--- a/projects/HSLink-Pro/src/setting.cpp
+++ b/projects/HSLink-Pro/src/setting.cpp
@@ -83,7 +83,7 @@ static std::string stringify_settings() {
             writer.String("nrst");
         }
         if (SETTING_GET_RESET_MODE(HSLink_Setting.reset, RESET_ARM_SWD_SOFT)) {
-            writer.String("swd_soft");
+            writer.String("arm_swd_soft");
         }
         if (SETTING_GET_RESET_MODE(HSLink_Setting.reset, RESET_POR)) {
             writer.String("por");


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Updated the reset mode labeling in settings output to display the correct terminology.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->