### PR TITLE
Jtag single bit

### DIFF
--- a/docs/src/projects/HSLink Pro.md
+++ b/docs/src/projects/HSLink Pro.md
@@ -65,6 +65,10 @@ HSLink Pro 的引脚定义满足 [20-pin J-Link Connector](https://wiki.segger.c
 * SWD/JTAG输出方式
   * SPI模式为使用SPI外设模拟时序
   * GPIO模式为GPIO模拟时序
+  * JTAG_SHIFT 加速
+    * 该设置项只有当JTAG输出方式设置为SPI时才会生效
+    * 选择启用代表将使用SPI外设模拟JTAG的单bit数据（可能会导致一些兼容性问题）
+    * 选择禁用代表将使用GPIO模拟JTAG的单bit数据（兼容性较好）
 
 * 参考电压
   * 在Vref没有电压输入或电压小于等于1.6V时，调试器内部Tvcc的电压

--- a/projects/HSLink-Pro/src/HID_COMM/hid_comm.cpp
+++ b/projects/HSLink-Pro/src/HID_COMM/hid_comm.cpp
@@ -380,7 +380,7 @@ static void write_bl_b(Document &root, char *res) {
     auto data_b64_len = root["data"].GetStringLength();
     log_d("addr: 0x%X, len: %d, data_len: %d", addr, len, data_b64_len);
     //    elog_hexdump("b64", 16, data_b64, data_b64_len);
-    if (addr + len > bl_b_part->len) {
+    if (size_t(addr + len) > bl_b_part->len) {
         const char *message = "addr out of range";
         USB_LOG_WRN("%s\n", message);
         FillStatus(HID_RESPONSE_FAILED, res, message);
@@ -402,7 +402,7 @@ static void write_bl_b(Document &root, char *res) {
     uint8_t *data = b64_decode_ex(data_b64, data_b64_len, &data_len);
     log_d("solve b64 data_len: %d", data_len);
     //    elog_hexdump(LOG_TAG, 16, data, data_len);
-    if (data_len != len) {
+    if (data_len != (size_t)len) {
         log_w("data_len != len");
         FillStatus(HID_RESPONSE_FAILED, res, "data_len != len");
         return;
@@ -430,7 +430,7 @@ static void upgrade_bl(Document &root, char *res) {
     auto len = root["len"].GetInt();
     auto crc_str = root["crc"].GetString();
     auto crc = strtoul(crc_str + 2, nullptr, 16);
-    if (len > bl_b_part->len) {
+    if ((size_t)len > bl_b_part->len) {
         char msg[64];
         snprintf(msg, sizeof(msg), "len %d > %d", len, bl_b_part->len);
         log_w(msg);
@@ -447,7 +447,7 @@ static void upgrade_bl(Document &root, char *res) {
         uint32_t crc_calc = 0xFFFFFFFF;
         const uint32_t CRC_CALC_LEN = 8 * 1024;
         auto buf = std::make_unique<uint8_t[]>(CRC_CALC_LEN);
-        for (uint32_t i = 0; i < len; i += CRC_CALC_LEN) {
+        for (uint32_t i = 0; i < (size_t)len; i += CRC_CALC_LEN) {
             auto calc_len = std::min(CRC_CALC_LEN, len - i);
             fal_partition_read(bl_b_part, i, buf.get(), calc_len);
             crc_calc = CRC_CalcArray_Software(buf.get(), calc_len, crc_calc);

--- a/projects/HSLink-Pro/src/JTAG_DP/JTAG_DP_SPI.c
+++ b/projects/HSLink-Pro/src/JTAG_DP/JTAG_DP_SPI.c
@@ -30,16 +30,18 @@
 #include "board.h"
 #include "hpm_spi_drv.h"
 #include "hpm_clock_drv.h"
+
 #ifdef HPMSOC_HAS_HPMSDK_DMAV2
+
 #include "hpm_dmav2_drv.h"
+
 #else
 #include "hpm_dma_drv.h"
 #endif
+
 #include "hpm_dmamux_drv.h"
 
 // JTAG Macros
-
-#define USE_GPIO_1_BIT         0
 
 #define PIN_JTAG_GPIO          HPM_GPIO0
 
@@ -60,11 +62,17 @@
 
 #define PIN_JTAG_DELAY() PIN_DELAY_SLOW(DAP_Data.clock_delay)
 
-static void jtag_spi_sequece (uint32_t info, const uint8_t *tdi, uint8_t *tdo);
+static void jtag_spi_sequece(uint32_t info, const uint8_t *tdi, uint8_t *tdo);
+
 static void jtag_spi_ir_fast(uint32_t ir, uint16_t ir_before, uint8_t ir_length, uint16_t ir_after);
-static uint8_t jtag_spi_transfer_fast(uint32_t request, uint32_t *data, uint8_t index_count, uint8_t index, uint8_t idle_cycles);
+
+static uint8_t
+jtag_spi_transfer_fast(uint32_t request, uint32_t *data, uint8_t index_count, uint8_t index, uint8_t idle_cycles);
+
 static uint32_t jtag_spi_read_idcode(uint8_t index);
+
 static void jtag_spi_write_abort(uint32_t data, uint8_t index_count, uint8_t index);
+
 static void jtag_emulation_init(void);
 
 #if (DAP_JTAG != 0)
@@ -75,7 +83,8 @@ void SPI_PORT_JTAG_SETUP(void)
     clock_add_to_group(JTAG_SPI_BASE_CLOCK_NAME, 0);
     clock_set_source_divider(JTAG_SPI_BASE_CLOCK_NAME, clk_src_pll1_clk0, 10U); /* 80MHz */
     HPM_IOC->PAD[IOC_PAD_PB10].FUNC_CTL = IOC_PB10_FUNC_CTL_GPIO_B_10;
-    HPM_IOC->PAD[PIN_JTAG_TCK].FUNC_CTL = IOC_PAD_FUNC_CTL_ALT_SELECT_SET(5) | IOC_PAD_FUNC_CTL_LOOP_BACK_SET(1); /* as spi sck*/
+    HPM_IOC->PAD[PIN_JTAG_TCK].FUNC_CTL =
+            IOC_PAD_FUNC_CTL_ALT_SELECT_SET(5) | IOC_PAD_FUNC_CTL_LOOP_BACK_SET(1); /* as spi sck*/
     HPM_IOC->PAD[PIN_JTAG_TDO].FUNC_CTL = IOC_PAD_FUNC_CTL_ALT_SELECT_SET(5); /* as spi mosi */
     HPM_IOC->PAD[PIN_JTAG_TDI].FUNC_CTL = IOC_PAD_FUNC_CTL_ALT_SELECT_SET(5); /** as spi miso */
     HPM_IOC->PAD[PIN_SINGLE_SPI_JTAG_TMS].FUNC_CTL = IOC_PA29_FUNC_CTL_GPIO_A_29;
@@ -84,10 +93,16 @@ void SPI_PORT_JTAG_SETUP(void)
     HPM_IOC->PAD[IOC_PAD_PB10].PAD_CTL = IOC_PAD_PAD_CTL_SR_MASK | IOC_PAD_PAD_CTL_SPD_SET(3);
     HPM_IOC->PAD[PIN_JTAG_TCK].PAD_CTL = IOC_PAD_PAD_CTL_SR_MASK | IOC_PAD_PAD_CTL_SPD_SET(3);
     HPM_IOC->PAD[PIN_JTAG_TDO].PAD_CTL = IOC_PAD_PAD_CTL_SR_MASK | IOC_PAD_PAD_CTL_SPD_SET(3);
-    HPM_IOC->PAD[PIN_JTAG_TDI].PAD_CTL = IOC_PAD_PAD_CTL_SR_MASK | IOC_PAD_PAD_CTL_SPD_SET(3) | IOC_PAD_PAD_CTL_PE_SET(1) | IOC_PAD_PAD_CTL_PS_SET(0);
+    HPM_IOC->PAD[PIN_JTAG_TDI].PAD_CTL =
+            IOC_PAD_PAD_CTL_SR_MASK | IOC_PAD_PAD_CTL_SPD_SET(3) | IOC_PAD_PAD_CTL_PE_SET(1) |
+            IOC_PAD_PAD_CTL_PS_SET(0);
     HPM_IOC->PAD[PIN_SINGLE_SPI_JTAG_TMS].PAD_CTL = IOC_PAD_PAD_CTL_SR_MASK | IOC_PAD_PAD_CTL_SPD_SET(3);
-    HPM_IOC->PAD[PIN_SRST].PAD_CTL = IOC_PAD_PAD_CTL_PRS_SET(2) | IOC_PAD_PAD_CTL_PE_SET(1) | IOC_PAD_PAD_CTL_PS_SET(1) | IOC_PAD_PAD_CTL_SPD_SET(3);
-    HPM_IOC->PAD[PIN_JTAG_TRST].PAD_CTL = IOC_PAD_PAD_CTL_PRS_SET(2) | IOC_PAD_PAD_CTL_PE_SET(1) | IOC_PAD_PAD_CTL_PS_SET(1) | IOC_PAD_PAD_CTL_SPD_SET(3);
+    HPM_IOC->PAD[PIN_SRST].PAD_CTL =
+            IOC_PAD_PAD_CTL_PRS_SET(2) | IOC_PAD_PAD_CTL_PE_SET(1) | IOC_PAD_PAD_CTL_PS_SET(1) |
+            IOC_PAD_PAD_CTL_SPD_SET(3);
+    HPM_IOC->PAD[PIN_JTAG_TRST].PAD_CTL =
+            IOC_PAD_PAD_CTL_PRS_SET(2) | IOC_PAD_PAD_CTL_PE_SET(1) | IOC_PAD_PAD_CTL_PS_SET(1) |
+            IOC_PAD_PAD_CTL_SPD_SET(3);
     gpiom_configure_pin_control_setting(PIN_SINGLE_SPI_JTAG_TMS);
     gpiom_configure_pin_control_setting(PIN_SRST);
     gpiom_configure_pin_control_setting(PIN_JTAG_TRST);
@@ -102,20 +117,22 @@ void SPI_PORT_JTAG_SETUP(void)
     gpio_set_pin_output(PIN_GPIO, GPIO_GET_PORT_INDEX(PIN_JTAG_TRST), GPIO_GET_PIN_INDEX(PIN_JTAG_TRST));
     gpio_write_pin(PIN_GPIO, GPIO_GET_PORT_INDEX(PIN_JTAG_TRST), GPIO_GET_PIN_INDEX(PIN_JTAG_TRST), 1);
 
-    gpio_set_pin_output(PIN_JTAG_GPIO, GPIO_GET_PORT_INDEX(PIN_SINGLE_SPI_JTAG_TMS), GPIO_GET_PIN_INDEX(PIN_SINGLE_SPI_JTAG_TMS));
+    gpio_set_pin_output(PIN_JTAG_GPIO, GPIO_GET_PORT_INDEX(PIN_SINGLE_SPI_JTAG_TMS),
+                        GPIO_GET_PIN_INDEX(PIN_SINGLE_SPI_JTAG_TMS));
 
-    gpio_write_pin(PIN_SWDIO_DIR_GPIO, GPIO_GET_PORT_INDEX(SWDIO_DIR), GPIO_GET_PIN_INDEX(SWDIO_DIR), 1); // TMS引脚在JTAG下始终为输出
+    gpio_write_pin(PIN_SWDIO_DIR_GPIO, GPIO_GET_PORT_INDEX(SWDIO_DIR), GPIO_GET_PIN_INDEX(SWDIO_DIR),
+                   1); // TMS引脚在JTAG下始终为输出
 
-#if defined(USE_GPIO_1_BIT) && (USE_GPIO_1_BIT == 1)
-    gpiom_configure_pin_control_setting(PIN_JTAG_TCK);
-    gpiom_configure_pin_control_setting(PIN_JTAG_TDO);
-    gpiom_configure_pin_control_setting(PIN_JTAG_TDI);
-    gpiom_configure_pin_control_setting(IOC_PAD_PB10);
-    gpio_set_pin_output(PIN_JTAG_GPIO, GPIO_GET_PORT_INDEX(IOC_PAD_PB10), GPIO_GET_PIN_INDEX(IOC_PAD_PB10));
-    gpio_set_pin_output(PIN_JTAG_GPIO, GPIO_GET_PORT_INDEX(PIN_JTAG_TCK), GPIO_GET_PIN_INDEX(PIN_JTAG_TCK));
-    gpio_set_pin_output(PIN_JTAG_GPIO, GPIO_GET_PORT_INDEX(PIN_JTAG_TDI), GPIO_GET_PIN_INDEX(PIN_JTAG_TDI));
-    gpio_set_pin_input(PIN_JTAG_GPIO, GPIO_GET_PORT_INDEX(PIN_JTAG_TDO), GPIO_GET_PIN_INDEX(PIN_JTAG_TDO));
-#endif
+    if (HSLink_Setting.jtag_single_bit_mode) {
+        gpiom_configure_pin_control_setting(PIN_JTAG_TCK);
+        gpiom_configure_pin_control_setting(PIN_JTAG_TDO);
+        gpiom_configure_pin_control_setting(PIN_JTAG_TDI);
+        gpiom_configure_pin_control_setting(IOC_PAD_PB10);
+        gpio_set_pin_output(PIN_JTAG_GPIO, GPIO_GET_PORT_INDEX(IOC_PAD_PB10), GPIO_GET_PIN_INDEX(IOC_PAD_PB10));
+        gpio_set_pin_output(PIN_JTAG_GPIO, GPIO_GET_PORT_INDEX(PIN_JTAG_TCK), GPIO_GET_PIN_INDEX(PIN_JTAG_TCK));
+        gpio_set_pin_output(PIN_JTAG_GPIO, GPIO_GET_PORT_INDEX(PIN_JTAG_TDI), GPIO_GET_PIN_INDEX(PIN_JTAG_TDI));
+        gpio_set_pin_input(PIN_JTAG_GPIO, GPIO_GET_PORT_INDEX(PIN_JTAG_TDO), GPIO_GET_PIN_INDEX(PIN_JTAG_TDO));
+    }
     jtag_emulation_init();
 }
 
@@ -124,7 +141,8 @@ void SPI_PORT_JTAG_SETUP(void)
 //   tdi:    pointer to TDI generated data
 //   tdo:    pointer to TDO captured data
 //   return: none
-void SPI_JTAG_Sequence (uint32_t info, const uint8_t *tdi, uint8_t *tdo) {
+void SPI_JTAG_Sequence(uint32_t info, const uint8_t *tdi, uint8_t *tdo)
+{
     jtag_spi_sequece(info, tdi, tdo);
 }
 
@@ -159,7 +177,8 @@ static uint8_t JTAG_TransferSlow(uint32_t request, uint32_t *data)
 
 // JTAG Read IDCODE register
 //   return: value read
-uint32_t SPI_JTAG_ReadIDCode (void) {
+uint32_t SPI_JTAG_ReadIDCode(void)
+{
     uint8_t index = DAP_Data.jtag_dev.index;
     return jtag_spi_read_idcode(index);
 }
@@ -168,7 +187,8 @@ uint32_t SPI_JTAG_ReadIDCode (void) {
 // JTAG Write ABORT register
 //   data:   value to write
 //   return: none
-void SPI_JTAG_WriteAbort (uint32_t data) {
+void SPI_JTAG_WriteAbort(uint32_t data)
+{
     uint8_t index_count, index;
     index_count = DAP_Data.jtag_dev.count;
     index = DAP_Data.jtag_dev.index;
@@ -179,12 +199,13 @@ void SPI_JTAG_WriteAbort (uint32_t data) {
 // JTAG Set IR
 //   ir:     IR value
 //   return: none
-void SPI_JTAG_IR (uint32_t ir) {
-  if (DAP_Data.fast_clock) {
-    JTAG_IR_Fast(ir);
-  } else {
-    JTAG_IR_Slow(ir);
-  }
+void SPI_JTAG_IR(uint32_t ir)
+{
+    if (DAP_Data.fast_clock) {
+        JTAG_IR_Fast(ir);
+    } else {
+        JTAG_IR_Slow(ir);
+    }
 }
 
 
@@ -192,12 +213,13 @@ void SPI_JTAG_IR (uint32_t ir) {
 //   request: A[3:2] RnW APnDP
 //   data:    DATA[31:0]
 //   return:  ACK[2:0]
-uint8_t  SPI_JTAG_Transfer(uint32_t request, uint32_t *data) {
-  if (DAP_Data.fast_clock) {
-    return JTAG_TransferFast(request, data);
-  } else {
-    return JTAG_TransferSlow(request, data);
-  }
+uint8_t SPI_JTAG_Transfer(uint32_t request, uint32_t *data)
+{
+    if (DAP_Data.fast_clock) {
+        return JTAG_TransferFast(request, data);
+    } else {
+        return JTAG_TransferSlow(request, data);
+    }
 }
 
 
@@ -258,7 +280,7 @@ static void jtag_more_than_32bit_size_for_tck(uint16_t bit_size, uint32_t dummy)
 //   tdi:    pointer to TDI generated data
 //   tdo:    pointer to TDO captured data
 //   return: none
-static void jtag_spi_sequece (uint32_t info, const uint8_t *tdi, uint8_t *tdo)
+static void jtag_spi_sequece(uint32_t info, const uint8_t *tdi, uint8_t *tdo)
 {
     uint32_t n;
     uint32_t n_len_in_byte = 0;
@@ -269,59 +291,63 @@ static void jtag_spi_sequece (uint32_t info, const uint8_t *tdi, uint8_t *tdo)
     uint8_t txfifo_valid_size = 0, rxfifo_valid_size = 0, j = 0;
     n = info & JTAG_SEQUENCE_TCK;
     if (info & JTAG_SEQUENCE_TMS) {
-         //printf("1s: %d %d\n", n_len_in_byte, n_len_remain_bit);
-          gpio_write_pin(PIN_JTAG_GPIO, GPIO_GET_PORT_INDEX(PIN_SINGLE_SPI_JTAG_TMS), GPIO_GET_PIN_INDEX(PIN_SINGLE_SPI_JTAG_TMS), true);
+        //printf("1s: %d %d\n", n_len_in_byte, n_len_remain_bit);
+        gpio_write_pin(PIN_JTAG_GPIO, GPIO_GET_PORT_INDEX(PIN_SINGLE_SPI_JTAG_TMS),
+                       GPIO_GET_PIN_INDEX(PIN_SINGLE_SPI_JTAG_TMS), true);
     } else {
-         //printf("0s: %d %d\n", n_len_in_byte, n_len_remain_bit);
-         gpio_write_pin(PIN_JTAG_GPIO, GPIO_GET_PORT_INDEX(PIN_SINGLE_SPI_JTAG_TMS), GPIO_GET_PIN_INDEX(PIN_SINGLE_SPI_JTAG_TMS), false);
+        //printf("0s: %d %d\n", n_len_in_byte, n_len_remain_bit);
+        gpio_write_pin(PIN_JTAG_GPIO, GPIO_GET_PORT_INDEX(PIN_SINGLE_SPI_JTAG_TMS),
+                       GPIO_GET_PIN_INDEX(PIN_SINGLE_SPI_JTAG_TMS), false);
     }
     if (n == 1) {
-#if defined(USE_GPIO_1_BIT) && (USE_GPIO_1_BIT == 1)
+        if (HSLink_Setting.jtag_single_bit_mode) {
 
-        HPM_IOC->PAD[PIN_JTAG_TCK].FUNC_CTL = IOC_PAD_FUNC_CTL_ALT_SELECT_SET(0);
-        HPM_IOC->PAD[PIN_JTAG_TDI].FUNC_CTL = IOC_PAD_FUNC_CTL_ALT_SELECT_SET(0);
-        PIN_JTAG_DELAY();
-        if((*tdi) & 0x01) {
-            gpio_write_pin(PIN_JTAG_GPIO, GPIO_GET_PORT_INDEX(PIN_JTAG_TDI), GPIO_GET_PIN_INDEX(PIN_JTAG_TDI), true);
-        }
-        else {
-            gpio_write_pin(PIN_JTAG_GPIO, GPIO_GET_PORT_INDEX(PIN_JTAG_TDI), GPIO_GET_PIN_INDEX(PIN_JTAG_TDI), false);
-        }
-        gpio_write_pin(PIN_JTAG_GPIO, GPIO_GET_PORT_INDEX(PIN_JTAG_TCK), GPIO_GET_PIN_INDEX(PIN_JTAG_TCK), true);
-        // PIN_JTAG_DELAY();
-        if (info & JTAG_SEQUENCE_TDO) {
-            (*tdo) = gpio_read_pin(PIN_JTAG_GPIO, GPIO_GET_PORT_INDEX(PIN_JTAG_TDO), GPIO_GET_PIN_INDEX(PIN_JTAG_TDO));
-        }
-        gpio_write_pin(PIN_JTAG_GPIO, GPIO_GET_PORT_INDEX(PIN_JTAG_TCK), GPIO_GET_PIN_INDEX(PIN_JTAG_TCK), false);
-        // PIN_JTAG_DELAY();
-        HPM_IOC->PAD[PIN_JTAG_TCK].FUNC_CTL = IOC_PAD_FUNC_CTL_ALT_SELECT_SET(5) | IOC_PAD_FUNC_CTL_LOOP_BACK_SET(1); 
-        HPM_IOC->PAD[PIN_JTAG_TDO].FUNC_CTL = IOC_PAD_FUNC_CTL_ALT_SELECT_SET(5);
-        HPM_IOC->PAD[PIN_JTAG_TDI].FUNC_CTL = IOC_PAD_FUNC_CTL_ALT_SELECT_SET(5);
-        return;
-#else
-        switch ((*tdi) & 0x01)
-        {
-        case 1:
-            JTAG_SPI_BASE->DIRECTIO = 0x1040400;
-            JTAG_SPI_BASE->DIRECTIO = 0x1060600; /* diretion = 1, slck_oe = 1, mosi_oe = 1, sclk_o = 1, mosi_o = 1 */
-            if (is_tdo == true) {
-                *(uint8_t *)(tdo) = (uint8_t)(JTAG_SPI_BASE->DIRECTIO >> 3);
+            HPM_IOC->PAD[PIN_JTAG_TCK].FUNC_CTL = IOC_PAD_FUNC_CTL_ALT_SELECT_SET(0);
+            HPM_IOC->PAD[PIN_JTAG_TDI].FUNC_CTL = IOC_PAD_FUNC_CTL_ALT_SELECT_SET(0);
+            PIN_JTAG_DELAY();
+            if ((*tdi) & 0x01) {
+                gpio_write_pin(PIN_JTAG_GPIO, GPIO_GET_PORT_INDEX(PIN_JTAG_TDI), GPIO_GET_PIN_INDEX(PIN_JTAG_TDI),
+                               true);
+            } else {
+                gpio_write_pin(PIN_JTAG_GPIO, GPIO_GET_PORT_INDEX(PIN_JTAG_TDI), GPIO_GET_PIN_INDEX(PIN_JTAG_TDI),
+                               false);
             }
-            JTAG_SPI_BASE->DIRECTIO = 0x1060400; /* diretion = 1, slck_oe = 1, mosi_oe = 1, sclk_o = 0, mosi_o = 1*/
-            break;
-        case 0:
-            JTAG_SPI_BASE->DIRECTIO = 0x1040000;
-            JTAG_SPI_BASE->DIRECTIO = 0x1060200; /* diretion = 1, slck_oe = 1, mosi_oe = 1, sclk_o = 1, mosi_o = 0 */
-            if (is_tdo == true) {
-                *(uint8_t *)(tdo) = (uint8_t)(JTAG_SPI_BASE->DIRECTIO >> 3);
+            gpio_write_pin(PIN_JTAG_GPIO, GPIO_GET_PORT_INDEX(PIN_JTAG_TCK), GPIO_GET_PIN_INDEX(PIN_JTAG_TCK), true);
+            // PIN_JTAG_DELAY();
+            if (info & JTAG_SEQUENCE_TDO) {
+                (*tdo) = gpio_read_pin(PIN_JTAG_GPIO, GPIO_GET_PORT_INDEX(PIN_JTAG_TDO),
+                                       GPIO_GET_PIN_INDEX(PIN_JTAG_TDO));
             }
-            JTAG_SPI_BASE->DIRECTIO = 0x1060000; /* diretion = 1, slck_oe = 1, mosi_oe = 1, sclk_o = 0, mosi_o = 0 */
-        default:
-            break;
+            gpio_write_pin(PIN_JTAG_GPIO, GPIO_GET_PORT_INDEX(PIN_JTAG_TCK), GPIO_GET_PIN_INDEX(PIN_JTAG_TCK), false);
+            // PIN_JTAG_DELAY();
+            HPM_IOC->PAD[PIN_JTAG_TCK].FUNC_CTL =
+                    IOC_PAD_FUNC_CTL_ALT_SELECT_SET(5) | IOC_PAD_FUNC_CTL_LOOP_BACK_SET(1);
+            HPM_IOC->PAD[PIN_JTAG_TDO].FUNC_CTL = IOC_PAD_FUNC_CTL_ALT_SELECT_SET(5);
+            HPM_IOC->PAD[PIN_JTAG_TDI].FUNC_CTL = IOC_PAD_FUNC_CTL_ALT_SELECT_SET(5);
+            return;
+        } else {
+            switch ((*tdi) & 0x01) {
+                case 1:
+                    JTAG_SPI_BASE->DIRECTIO = 0x1040400;
+                    JTAG_SPI_BASE->DIRECTIO = 0x1060600; /* diretion = 1, slck_oe = 1, mosi_oe = 1, sclk_o = 1, mosi_o = 1 */
+                    if (is_tdo == true) {
+                        *(uint8_t *) (tdo) = (uint8_t) (JTAG_SPI_BASE->DIRECTIO >> 3);
+                    }
+                    JTAG_SPI_BASE->DIRECTIO = 0x1060400; /* diretion = 1, slck_oe = 1, mosi_oe = 1, sclk_o = 0, mosi_o = 1*/
+                    break;
+                case 0:
+                    JTAG_SPI_BASE->DIRECTIO = 0x1040000;
+                    JTAG_SPI_BASE->DIRECTIO = 0x1060200; /* diretion = 1, slck_oe = 1, mosi_oe = 1, sclk_o = 1, mosi_o = 0 */
+                    if (is_tdo == true) {
+                        *(uint8_t *) (tdo) = (uint8_t) (JTAG_SPI_BASE->DIRECTIO >> 3);
+                    }
+                    JTAG_SPI_BASE->DIRECTIO = 0x1060000; /* diretion = 1, slck_oe = 1, mosi_oe = 1, sclk_o = 0, mosi_o = 0 */
+                default:
+                    break;
+            }
+            JTAG_SPI_BASE->DIRECTIO = 0; /* diretion = 0 */
+            return;
         }
-        JTAG_SPI_BASE->DIRECTIO = 0; /* diretion = 0 */
-        return;
-#endif
     }
 
     jtag_reset();
@@ -381,11 +407,11 @@ static void jtag_spi_sequece (uint32_t info, const uint8_t *tdi, uint8_t *tdo)
         spi_set_read_data_count(JTAG_SPI_BASE, 1);
         spi_set_write_data_count(JTAG_SPI_BASE, 1);
         JTAG_SPI_BASE->CMD = 0xFF; /* Write a dummy byte */
-        JTAG_SPI_BASE->DATA = *(uint8_t *)(tdi);
+        JTAG_SPI_BASE->DATA = *(uint8_t *) (tdi);
         if (is_tdo == true) {
             while ((JTAG_SPI_BASE->STATUS & SPI_STATUS_RXEMPTY_MASK) == SPI_STATUS_RXEMPTY_MASK) {
             };
-            *(uint8_t *)(tdo) = JTAG_SPI_BASE->DATA;
+            *(uint8_t *) (tdo) = JTAG_SPI_BASE->DATA;
         }
         while (JTAG_SPI_BASE->STATUS & SPI_STATUS_SPIACTIVE_MASK) {
         };
@@ -407,10 +433,12 @@ static void jtag_spi_ir_fast(uint32_t ir, uint16_t ir_before, uint8_t ir_length,
 {
     spi_set_transfer_mode(JTAG_SPI_BASE, spi_trans_write_only);
     /* Select-DR-Scan  and Select-IR-Scan */
-    gpio_write_pin(PIN_JTAG_GPIO, GPIO_GET_PORT_INDEX(PIN_SINGLE_SPI_JTAG_TMS), GPIO_GET_PIN_INDEX(PIN_SINGLE_SPI_JTAG_TMS), true);
+    gpio_write_pin(PIN_JTAG_GPIO, GPIO_GET_PORT_INDEX(PIN_SINGLE_SPI_JTAG_TMS),
+                   GPIO_GET_PIN_INDEX(PIN_SINGLE_SPI_JTAG_TMS), true);
     jtag_less_than_32bit_size_for_tck(2, 0);
-      /* Capture-IR   and Shift-IR */
-    gpio_write_pin(PIN_JTAG_GPIO, GPIO_GET_PORT_INDEX(PIN_SINGLE_SPI_JTAG_TMS), GPIO_GET_PIN_INDEX(PIN_SINGLE_SPI_JTAG_TMS), false);
+    /* Capture-IR   and Shift-IR */
+    gpio_write_pin(PIN_JTAG_GPIO, GPIO_GET_PORT_INDEX(PIN_SINGLE_SPI_JTAG_TMS),
+                   GPIO_GET_PIN_INDEX(PIN_SINGLE_SPI_JTAG_TMS), false);
     jtag_less_than_32bit_size_for_tck(2, 0);
     if (ir_before) {
         if (ir_before > 32) {
@@ -433,33 +461,39 @@ static void jtag_spi_ir_fast(uint32_t ir, uint16_t ir_before, uint8_t ir_length,
             jtag_less_than_32bit_size_for_tck(ir_after, 0xFFFFFFFF);
         }
         /* Bypass & Exit1-IR */
-        gpio_write_pin(PIN_JTAG_GPIO, GPIO_GET_PORT_INDEX(PIN_SINGLE_SPI_JTAG_TMS), GPIO_GET_PIN_INDEX(PIN_SINGLE_SPI_JTAG_TMS), true);
+        gpio_write_pin(PIN_JTAG_GPIO, GPIO_GET_PORT_INDEX(PIN_SINGLE_SPI_JTAG_TMS),
+                       GPIO_GET_PIN_INDEX(PIN_SINGLE_SPI_JTAG_TMS), true);
         jtag_less_than_32bit_size_for_tck(1, 0xFFFFFFFF);
     } else {
         /* Set last IR bit & Exit1-IR  */
-        gpio_write_pin(PIN_JTAG_GPIO, GPIO_GET_PORT_INDEX(PIN_SINGLE_SPI_JTAG_TMS), GPIO_GET_PIN_INDEX(PIN_SINGLE_SPI_JTAG_TMS), true);
+        gpio_write_pin(PIN_JTAG_GPIO, GPIO_GET_PORT_INDEX(PIN_SINGLE_SPI_JTAG_TMS),
+                       GPIO_GET_PIN_INDEX(PIN_SINGLE_SPI_JTAG_TMS), true);
         jtag_less_than_32bit_size_for_tck(1, ir);
     }
     /* Update-IR */
     jtag_less_than_32bit_size_for_tck(1, 0);
     /* Idle */
-    gpio_write_pin(PIN_JTAG_GPIO, GPIO_GET_PORT_INDEX(PIN_SINGLE_SPI_JTAG_TMS), GPIO_GET_PIN_INDEX(PIN_SINGLE_SPI_JTAG_TMS), false);
+    gpio_write_pin(PIN_JTAG_GPIO, GPIO_GET_PORT_INDEX(PIN_SINGLE_SPI_JTAG_TMS),
+                   GPIO_GET_PIN_INDEX(PIN_SINGLE_SPI_JTAG_TMS), false);
     jtag_less_than_32bit_size_for_tck(1, 0xFFFFFFFF);
 }
 
-static uint8_t jtag_spi_transfer_fast(uint32_t request, uint32_t *data, uint8_t index_count, uint8_t index, uint8_t idle_cycles)
+static uint8_t
+jtag_spi_transfer_fast(uint32_t request, uint32_t *data, uint8_t index_count, uint8_t index, uint8_t idle_cycles)
 {
     uint32_t ack = 0;
     uint32_t bit = 0;
     uint32_t n = 0;
     uint32_t val;
     /* Select-DR-Scan */
-    gpio_write_pin(PIN_JTAG_GPIO, GPIO_GET_PORT_INDEX(PIN_SINGLE_SPI_JTAG_TMS), GPIO_GET_PIN_INDEX(PIN_SINGLE_SPI_JTAG_TMS), true);
+    gpio_write_pin(PIN_JTAG_GPIO, GPIO_GET_PORT_INDEX(PIN_SINGLE_SPI_JTAG_TMS),
+                   GPIO_GET_PIN_INDEX(PIN_SINGLE_SPI_JTAG_TMS), true);
     jtag_less_than_32bit_size_for_tck(1, 0);
-    /* Capture-DR & Shift-DR */  
-    gpio_write_pin(PIN_JTAG_GPIO, GPIO_GET_PORT_INDEX(PIN_SINGLE_SPI_JTAG_TMS), GPIO_GET_PIN_INDEX(PIN_SINGLE_SPI_JTAG_TMS), false);
+    /* Capture-DR & Shift-DR */
+    gpio_write_pin(PIN_JTAG_GPIO, GPIO_GET_PORT_INDEX(PIN_SINGLE_SPI_JTAG_TMS),
+                   GPIO_GET_PIN_INDEX(PIN_SINGLE_SPI_JTAG_TMS), false);
     jtag_less_than_32bit_size_for_tck(2, 0);
-     /* Bypass before data */
+    /* Bypass before data */
     if (index) {
         if (index > 32) {
             jtag_more_than_32bit_size_for_tck(index, 0xFFFFFFFF); /* Bypass before data */
@@ -482,7 +516,8 @@ static uint8_t jtag_spi_transfer_fast(uint32_t request, uint32_t *data, uint8_t 
     };
     ack = ((bit & 0x01) << 1) | ((bit & 0x02) >> 1) | (bit & 0x04);
     if (ack != DAP_TRANSFER_OK) {
-        gpio_write_pin(PIN_JTAG_GPIO, GPIO_GET_PORT_INDEX(PIN_SINGLE_SPI_JTAG_TMS), GPIO_GET_PIN_INDEX(PIN_SINGLE_SPI_JTAG_TMS), true);
+        gpio_write_pin(PIN_JTAG_GPIO, GPIO_GET_PORT_INDEX(PIN_SINGLE_SPI_JTAG_TMS),
+                       GPIO_GET_PIN_INDEX(PIN_SINGLE_SPI_JTAG_TMS), true);
         jtag_less_than_32bit_size_for_tck(1, 0xFFFFFFFF);
         goto exit;
     }
@@ -509,7 +544,7 @@ static uint8_t jtag_spi_transfer_fast(uint32_t request, uint32_t *data, uint8_t 
         spi_set_read_data_count(JTAG_SPI_BASE, 1);
         spi_set_write_data_count(JTAG_SPI_BASE, 1);
         if (n) {
-            /* Get D31 */ 
+            /* Get D31 */
             JTAG_SPI_BASE->CMD = 0xFF; /* Write a dummy byte */
             while ((JTAG_SPI_BASE->STATUS & SPI_STATUS_RXEMPTY_MASK) == SPI_STATUS_RXEMPTY_MASK) {
             };
@@ -519,11 +554,13 @@ static uint8_t jtag_spi_transfer_fast(uint32_t request, uint32_t *data, uint8_t 
             /* Bypass after data */
             jtag_less_than_32bit_size_for_tck(n - 1, 0xFFFFFFFF);
             /* Bypass & Exit1-DR */
-            gpio_write_pin(PIN_JTAG_GPIO, GPIO_GET_PORT_INDEX(PIN_SINGLE_SPI_JTAG_TMS), GPIO_GET_PIN_INDEX(PIN_SINGLE_SPI_JTAG_TMS), true);
+            gpio_write_pin(PIN_JTAG_GPIO, GPIO_GET_PORT_INDEX(PIN_SINGLE_SPI_JTAG_TMS),
+                           GPIO_GET_PIN_INDEX(PIN_SINGLE_SPI_JTAG_TMS), true);
             jtag_less_than_32bit_size_for_tck(1, 0xFFFFFFFF);
         } else {
             /* Get D31 & Exit1-DR */
-            gpio_write_pin(PIN_JTAG_GPIO, GPIO_GET_PORT_INDEX(PIN_SINGLE_SPI_JTAG_TMS), GPIO_GET_PIN_INDEX(PIN_SINGLE_SPI_JTAG_TMS), true);
+            gpio_write_pin(PIN_JTAG_GPIO, GPIO_GET_PORT_INDEX(PIN_SINGLE_SPI_JTAG_TMS),
+                           GPIO_GET_PIN_INDEX(PIN_SINGLE_SPI_JTAG_TMS), true);
             JTAG_SPI_BASE->CMD = 0xFF; /* Write a dummy byte */
             while ((JTAG_SPI_BASE->STATUS & SPI_STATUS_RXEMPTY_MASK) == SPI_STATUS_RXEMPTY_MASK) {
             };
@@ -536,7 +573,7 @@ static uint8_t jtag_spi_transfer_fast(uint32_t request, uint32_t *data, uint8_t 
             *data = val;
         }
     } else {
-        /* Write Transfer */ 
+        /* Write Transfer */
         val = (*data);
         spi_set_transfer_mode(JTAG_SPI_BASE, spi_trans_write_only);
         /* Set D0..D30 */
@@ -554,22 +591,26 @@ static uint8_t jtag_spi_transfer_fast(uint32_t request, uint32_t *data, uint8_t 
             /* Bypass after data */
             jtag_less_than_32bit_size_for_tck(n - 1, 0);
             /* Bypass & Exit1-DR */
-            gpio_write_pin(PIN_JTAG_GPIO, GPIO_GET_PORT_INDEX(PIN_SINGLE_SPI_JTAG_TMS), GPIO_GET_PIN_INDEX(PIN_SINGLE_SPI_JTAG_TMS), true);
+            gpio_write_pin(PIN_JTAG_GPIO, GPIO_GET_PORT_INDEX(PIN_SINGLE_SPI_JTAG_TMS),
+                           GPIO_GET_PIN_INDEX(PIN_SINGLE_SPI_JTAG_TMS), true);
             jtag_less_than_32bit_size_for_tck(1, 0);
         } else {
-            gpio_write_pin(PIN_JTAG_GPIO, GPIO_GET_PORT_INDEX(PIN_SINGLE_SPI_JTAG_TMS), GPIO_GET_PIN_INDEX(PIN_SINGLE_SPI_JTAG_TMS), true);
+            gpio_write_pin(PIN_JTAG_GPIO, GPIO_GET_PORT_INDEX(PIN_SINGLE_SPI_JTAG_TMS),
+                           GPIO_GET_PIN_INDEX(PIN_SINGLE_SPI_JTAG_TMS), true);
             JTAG_SPI_BASE->CMD = 0xFF; /* Write a dummy byte */
             JTAG_SPI_BASE->DATA = val;
             while (JTAG_SPI_BASE->STATUS & SPI_STATUS_SPIACTIVE_MASK) {
             };
         }
     }
-exit:
-    gpio_write_pin(PIN_JTAG_GPIO, GPIO_GET_PORT_INDEX(PIN_SINGLE_SPI_JTAG_TMS), GPIO_GET_PIN_INDEX(PIN_SINGLE_SPI_JTAG_TMS), 1);
-    /* Update-DR */ 
+    exit:
+    gpio_write_pin(PIN_JTAG_GPIO, GPIO_GET_PORT_INDEX(PIN_SINGLE_SPI_JTAG_TMS),
+                   GPIO_GET_PIN_INDEX(PIN_SINGLE_SPI_JTAG_TMS), 1);
+    /* Update-DR */
     jtag_less_than_32bit_size_for_tck(1, 0);
     board_write_spi_cs(BOARD_SPI_CS_PIN, false);
-    gpio_write_pin(PIN_JTAG_GPIO, GPIO_GET_PORT_INDEX(PIN_SINGLE_SPI_JTAG_TMS), GPIO_GET_PIN_INDEX(PIN_SINGLE_SPI_JTAG_TMS), 0);
+    gpio_write_pin(PIN_JTAG_GPIO, GPIO_GET_PORT_INDEX(PIN_SINGLE_SPI_JTAG_TMS),
+                   GPIO_GET_PIN_INDEX(PIN_SINGLE_SPI_JTAG_TMS), 0);
     /* Idle */
     jtag_less_than_32bit_size_for_tck(1, 0xFFFFFFFF);
 
@@ -578,24 +619,27 @@ exit:
         // DAP_Data.timestamp = TIMESTAMP_GET(); 
     }
 
-    gpio_write_pin(PIN_JTAG_GPIO, GPIO_GET_PORT_INDEX(PIN_SINGLE_SPI_JTAG_TMS), GPIO_GET_PIN_INDEX(PIN_SINGLE_SPI_JTAG_TMS), 0);
-    /* Idle cycles */ 
+    gpio_write_pin(PIN_JTAG_GPIO, GPIO_GET_PORT_INDEX(PIN_SINGLE_SPI_JTAG_TMS),
+                   GPIO_GET_PIN_INDEX(PIN_SINGLE_SPI_JTAG_TMS), 0);
+    /* Idle cycles */
     jtag_less_than_32bit_size_for_tck(idle_cycles, 0xFFFFFFFF);
-    return ((uint8_t)ack);
+    return ((uint8_t) ack);
 }
 
 // JTAG Read IDCODE register
 //   return: value read
-static uint32_t jtag_spi_read_idcode (uint8_t index)
+static uint32_t jtag_spi_read_idcode(uint8_t index)
 {
     uint32_t bit;
     uint32_t val;
     /* Select-DR-Scan */
-    gpio_write_pin(PIN_JTAG_GPIO, GPIO_GET_PORT_INDEX(PIN_SINGLE_SPI_JTAG_TMS), GPIO_GET_PIN_INDEX(PIN_SINGLE_SPI_JTAG_TMS), true);
+    gpio_write_pin(PIN_JTAG_GPIO, GPIO_GET_PORT_INDEX(PIN_SINGLE_SPI_JTAG_TMS),
+                   GPIO_GET_PIN_INDEX(PIN_SINGLE_SPI_JTAG_TMS), true);
     jtag_less_than_32bit_size_for_tck(1, 0);
 
-    /* Capture-DR & Shift-DR */  
-    gpio_write_pin(PIN_JTAG_GPIO, GPIO_GET_PORT_INDEX(PIN_SINGLE_SPI_JTAG_TMS), GPIO_GET_PIN_INDEX(PIN_SINGLE_SPI_JTAG_TMS), false);
+    /* Capture-DR & Shift-DR */
+    gpio_write_pin(PIN_JTAG_GPIO, GPIO_GET_PORT_INDEX(PIN_SINGLE_SPI_JTAG_TMS),
+                   GPIO_GET_PIN_INDEX(PIN_SINGLE_SPI_JTAG_TMS), false);
     jtag_less_than_32bit_size_for_tck(2, 0);
 
     /* Bypass before data */
@@ -621,7 +665,8 @@ static uint32_t jtag_spi_read_idcode (uint8_t index)
     spi_set_read_data_count(JTAG_SPI_BASE, 1);
     spi_set_write_data_count(JTAG_SPI_BASE, 1);
     /* Get D31 & Exit1-DR */
-    gpio_write_pin(PIN_JTAG_GPIO, GPIO_GET_PORT_INDEX(PIN_SINGLE_SPI_JTAG_TMS), GPIO_GET_PIN_INDEX(PIN_SINGLE_SPI_JTAG_TMS), true);
+    gpio_write_pin(PIN_JTAG_GPIO, GPIO_GET_PORT_INDEX(PIN_SINGLE_SPI_JTAG_TMS),
+                   GPIO_GET_PIN_INDEX(PIN_SINGLE_SPI_JTAG_TMS), true);
     JTAG_SPI_BASE->CMD = 0xFF; /* Write a dummy byte */
     while ((JTAG_SPI_BASE->STATUS & SPI_STATUS_RXEMPTY_MASK) == SPI_STATUS_RXEMPTY_MASK) {
     };
@@ -629,11 +674,13 @@ static uint32_t jtag_spi_read_idcode (uint8_t index)
     while (JTAG_SPI_BASE->STATUS & SPI_STATUS_SPIACTIVE_MASK) {
     };
     val |= bit << 31;
-    gpio_write_pin(PIN_JTAG_GPIO, GPIO_GET_PORT_INDEX(PIN_SINGLE_SPI_JTAG_TMS), GPIO_GET_PIN_INDEX(PIN_SINGLE_SPI_JTAG_TMS), 1);
-    /* Update-DR */ 
+    gpio_write_pin(PIN_JTAG_GPIO, GPIO_GET_PORT_INDEX(PIN_SINGLE_SPI_JTAG_TMS),
+                   GPIO_GET_PIN_INDEX(PIN_SINGLE_SPI_JTAG_TMS), 1);
+    /* Update-DR */
     jtag_less_than_32bit_size_for_tck(1, 0);
     board_write_spi_cs(BOARD_SPI_CS_PIN, false);
-    gpio_write_pin(PIN_JTAG_GPIO, GPIO_GET_PORT_INDEX(PIN_SINGLE_SPI_JTAG_TMS), GPIO_GET_PIN_INDEX(PIN_SINGLE_SPI_JTAG_TMS), 0);
+    gpio_write_pin(PIN_JTAG_GPIO, GPIO_GET_PORT_INDEX(PIN_SINGLE_SPI_JTAG_TMS),
+                   GPIO_GET_PIN_INDEX(PIN_SINGLE_SPI_JTAG_TMS), 0);
     /* Idle */
     jtag_less_than_32bit_size_for_tck(1, 0xFFFFFFFF);
     return (val);
@@ -642,15 +689,17 @@ static uint32_t jtag_spi_read_idcode (uint8_t index)
 // JTAG Write ABORT register
 //   data:   value to write
 //   return: none
-static void jtag_spi_write_abort (uint32_t data, uint8_t index_count, uint8_t index)
+static void jtag_spi_write_abort(uint32_t data, uint8_t index_count, uint8_t index)
 {
     uint32_t n = 0;
     /* Select-DR-Scan */
-    gpio_write_pin(PIN_JTAG_GPIO, GPIO_GET_PORT_INDEX(PIN_SINGLE_SPI_JTAG_TMS), GPIO_GET_PIN_INDEX(PIN_SINGLE_SPI_JTAG_TMS), true);
+    gpio_write_pin(PIN_JTAG_GPIO, GPIO_GET_PORT_INDEX(PIN_SINGLE_SPI_JTAG_TMS),
+                   GPIO_GET_PIN_INDEX(PIN_SINGLE_SPI_JTAG_TMS), true);
     jtag_less_than_32bit_size_for_tck(1, 0);
 
-    /* Capture-DR & Shift-DR */  
-     gpio_write_pin(PIN_JTAG_GPIO, GPIO_GET_PORT_INDEX(PIN_SINGLE_SPI_JTAG_TMS), GPIO_GET_PIN_INDEX(PIN_SINGLE_SPI_JTAG_TMS), false);
+    /* Capture-DR & Shift-DR */
+    gpio_write_pin(PIN_JTAG_GPIO, GPIO_GET_PORT_INDEX(PIN_SINGLE_SPI_JTAG_TMS),
+                   GPIO_GET_PIN_INDEX(PIN_SINGLE_SPI_JTAG_TMS), false);
     jtag_less_than_32bit_size_for_tck(2, 0);
 
     /* Bypass before data */
@@ -678,7 +727,7 @@ static void jtag_spi_write_abort (uint32_t data, uint8_t index_count, uint8_t in
     spi_set_read_data_count(JTAG_SPI_BASE, 1);
     spi_set_write_data_count(JTAG_SPI_BASE, 1);
     if (n) {
-         /* Bypass after data */
+        /* Bypass after data */
         JTAG_SPI_BASE->CMD = 0xFF; /* Write a dummy byte */
         JTAG_SPI_BASE->DATA = data;
         while (JTAG_SPI_BASE->STATUS & SPI_STATUS_SPIACTIVE_MASK) {
@@ -686,19 +735,22 @@ static void jtag_spi_write_abort (uint32_t data, uint8_t index_count, uint8_t in
         /* Bypass after data */
         jtag_less_than_32bit_size_for_tck(n - 1, 0);
         /* Bypass & Exit1-DR */
-        gpio_write_pin(PIN_JTAG_GPIO, GPIO_GET_PORT_INDEX(PIN_SINGLE_SPI_JTAG_TMS), GPIO_GET_PIN_INDEX(PIN_SINGLE_SPI_JTAG_TMS), true);
+        gpio_write_pin(PIN_JTAG_GPIO, GPIO_GET_PORT_INDEX(PIN_SINGLE_SPI_JTAG_TMS),
+                       GPIO_GET_PIN_INDEX(PIN_SINGLE_SPI_JTAG_TMS), true);
         jtag_less_than_32bit_size_for_tck(1, 0);
     } else {
         /* Set D31 & Exit1-DR */
-        gpio_write_pin(PIN_JTAG_GPIO, GPIO_GET_PORT_INDEX(PIN_SINGLE_SPI_JTAG_TMS), GPIO_GET_PIN_INDEX(PIN_SINGLE_SPI_JTAG_TMS), true);
+        gpio_write_pin(PIN_JTAG_GPIO, GPIO_GET_PORT_INDEX(PIN_SINGLE_SPI_JTAG_TMS),
+                       GPIO_GET_PIN_INDEX(PIN_SINGLE_SPI_JTAG_TMS), true);
         JTAG_SPI_BASE->CMD = 0xFF; /* Write a dummy byte */
         JTAG_SPI_BASE->DATA = data;
         while (JTAG_SPI_BASE->STATUS & SPI_STATUS_SPIACTIVE_MASK) {
         };
     }
-    /* Update-DR */ 
+    /* Update-DR */
     jtag_less_than_32bit_size_for_tck(1, 0);
-    gpio_write_pin(PIN_JTAG_GPIO, GPIO_GET_PORT_INDEX(PIN_SINGLE_SPI_JTAG_TMS), GPIO_GET_PIN_INDEX(PIN_SINGLE_SPI_JTAG_TMS), false);
+    gpio_write_pin(PIN_JTAG_GPIO, GPIO_GET_PORT_INDEX(PIN_SINGLE_SPI_JTAG_TMS),
+                   GPIO_GET_PIN_INDEX(PIN_SINGLE_SPI_JTAG_TMS), false);
     /* Idle */
     jtag_less_than_32bit_size_for_tck(1, 0xFFFFFFFF);
 }

--- a/projects/HSLink-Pro/src/setting.h
+++ b/projects/HSLink-Pro/src/setting.h
@@ -32,6 +32,7 @@ typedef struct {
     bool boost;
     PORT_Mode_t swd_port_mode;
     PORT_Mode_t jtag_port_mode;
+    bool jtag_single_bit_mode;
     Setting_Power_t power;
     uint8_t reset; //这是一个Bitmap，用来存储多种设置，每一位的功能见Setting_ResetBit_t
     bool led;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

This update introduces a new option in device settings that allows you to enable a dedicated JTAG Single-Bit Mode for enhanced hardware interface control and flexibility.

- **New Features**
	- Added a "JTAG Single-Bit Mode" setting in the device configuration for improved interfacing.
	- Enhanced JSON handling for settings, including the new `jtag_single_bit_mode`.
- **Bug Fixes**
	- Improved type safety in conditional checks related to settings.
- **Style**
	- Standardized formatting of function declarations for better readability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->