### PR TITLE
支持 HPM SDK 1.9.0

### DIFF
--- a/.github/workflows/HSLinkPro-build.yml
+++ b/.github/workflows/HSLinkPro-build.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Install HPM SDK
         run: |
           cd ~
-          git clone --branch v1.8.0 https://github.com/hpmicro/hpm_sdk.git --recursive
+          git clone --branch v1.9.0 https://github.com/hpmicro/hpm_sdk.git --recursive
 
       - name: Create Python Venv
         run: |

--- a/projects/HSLink-Pro/bootloader/third_party_components/port/neopixel/ws2812.cpp
+++ b/projects/HSLink-Pro/bootloader/third_party_components/port/neopixel/ws2812.cpp
@@ -62,7 +62,7 @@ extern "C" void WS2812_Init() {
 
                     spi_initialize_config_t init_config;
                     hpm_spi_get_default_init_config(&init_config);
-                    init_config.direction = msb_first;
+                    init_config.direction = spi_msb_first;
                     init_config.mode = spi_master_mode;
                     init_config.clk_phase = spi_sclk_sampling_odd_clk_edges;
                     init_config.clk_polarity = spi_sclk_low_idle;

--- a/projects/HSLink-Pro/src/HSLink_Pro_expansion.cpp
+++ b/projects/HSLink-Pro/src/HSLink_Pro_expansion.cpp
@@ -291,7 +291,7 @@ static void WS2812_Init(void) {
 
                     spi_initialize_config_t init_config;
                     hpm_spi_get_default_init_config(&init_config);
-                    init_config.direction = msb_first;
+                    init_config.direction = spi_msb_first;
                     init_config.mode = spi_master_mode;
                     init_config.clk_phase = spi_sclk_sampling_odd_clk_edges;
                     init_config.clk_polarity = spi_sclk_low_idle;


### PR DESCRIPTION
HPM SDK 1.9.0版本一个月前发布，稍微修改下支持最新版本的HPM SDK。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated build workflow to use HPM SDK version 1.9.0.

- **Bug Fixes**
  - Corrected SPI configuration for WS2812 LED initialization to ensure proper data transmission.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->