### PR TITLE
可以重写webusb弹框策略，hslink pro可通过app配置

### DIFF
--- a/dap_main.c
+++ b/dap_main.c
@@ -105,7 +105,8 @@ __ALIGN_BEGIN const uint8_t USBD_WinUSBDescriptorSetDescriptor[] = {
 #endif
 };
 
-__ALIGN_BEGIN const uint8_t USBD_BinaryObjectStoreDescriptor[] = {
+/* not const: iLandingPage is patched at runtime by chry_dap_webusb_popup_apply() */
+__ALIGN_BEGIN uint8_t USBD_BinaryObjectStoreDescriptor[] = {
     0x05,                         /* bLength */
     0x0f,                         /* bDescriptorType */
     WBVAL(USBD_BOS_WTOTALLENGTH), /* wTotalLength */
@@ -147,6 +148,22 @@ const uint8_t USBD_WebUSBURLDescriptor[URL_DESCRIPTOR_LENGTH] = {
     WEBUSB_URL_SCHEME_HTTPS,
     WEBUSB_URL_STRINGS
 };
+
+/* offset of iLandingPage in USBD_BinaryObjectStoreDescriptor:
+ * BOS header (5 bytes) + WebUSB device capability fields before iLandingPage (23 bytes) */
+#define USBD_WEBUSB_ILANDINGPAGE_OFFSET (5 + 23)
+
+/* implement by user to disable the WebUSB landing page popup */
+__WEAK bool chry_dap_webusb_popup_enabled(void)
+{
+    return true;
+}
+
+void chry_dap_webusb_popup_apply(void)
+{
+    /* iLandingPage == 0 stops browsers from popping up the landing page notification */
+    USBD_BinaryObjectStoreDescriptor[USBD_WEBUSB_ILANDINGPAGE_OFFSET] = chry_dap_webusb_popup_enabled() ? 1 : 0;
+}
 
 // clang-format off
 #define HID_DESC()                                                                                                                       \
@@ -514,6 +531,8 @@ void chry_dap_init(uint8_t busid, uint32_t reg_base)
     chry_ringbuffer_init(&g_usbrx, usbrx_ringbuffer, CONFIG_USBRX_RINGBUF_SIZE);
 
     DAP_Setup();
+
+    chry_dap_webusb_popup_apply();
 
     usbd_desc_register(0, &cmsisdap_descriptor);
 

--- a/dap_main.h
+++ b/dap_main.h
@@ -70,6 +70,12 @@ void chry_dap_init(uint8_t busid, uint32_t reg_base);
 
 void chry_dap_handle(void);
 
+/* implment by user to control the WebUSB landing page popup, default enabled */
+extern bool chry_dap_webusb_popup_enabled(void);
+
+/* apply chry_dap_webusb_popup_enabled() to the BOS descriptor */
+void chry_dap_webusb_popup_apply(void);
+
 void chry_dap_usb2uart_handle(void);
 
 /* implment by user */

--- a/projects/HSLink-Pro/src/HID_COMM/hid_comm.cpp
+++ b/projects/HSLink-Pro/src/HID_COMM/hid_comm.cpp
@@ -228,6 +228,8 @@ static void settings(Document &root, char *res)
 
     HSLink_Setting.jtag_20pin_compatible = get_json_value(data, "jtag_20pin_compatible", false);
 
+    HSLink_Setting.webusb_popup = get_json_value(data, "webusb_popup", true);
+
     Setting_Save();
 
     FillStatus(HID_RESPONSE_SUCCESS, res);
@@ -351,6 +353,9 @@ static void get_setting(Document &root, char *res)
 
     writer.Key("jtag_20pin_compatible");
     writer.Bool(HSLink_Setting.jtag_20pin_compatible);
+
+    writer.Key("webusb_popup");
+    writer.Bool(HSLink_Setting.webusb_popup);
 
     writer.EndObject();
 

--- a/projects/HSLink-Pro/src/setting.cpp
+++ b/projects/HSLink-Pro/src/setting.cpp
@@ -13,6 +13,7 @@
 #include "rapidjson/stringbuffer.h"
 #include "rapidjson/writer.h"
 #include "usb2uart.h"
+#include "dap_main.h"
 
 using namespace rapidjson;
 
@@ -28,6 +29,7 @@ const HSLink_Setting_t default_setting = {
         .reset = 1 << RESET_NRST,
         .led = true,
         .led_brightness = 10,
+        .webusb_popup = true,
 };
 
 HSLink_Setting_t HSLink_Setting = {
@@ -42,7 +44,12 @@ HSLink_Setting_t HSLink_Setting = {
         .reset = 0,
         .led = false,
         .led_brightness = 0,
+        .webusb_popup = true,
 };
+
+extern "C" bool chry_dap_webusb_popup_enabled(void) {
+    return HSLink_Setting.webusb_popup;
+}
 
 HSLink_Lazy_t HSLink_Global;
 
@@ -146,6 +153,9 @@ static std::string stringify_settings()
     writer.Key("jtag_20pin_compatible");
     writer.Bool(HSLink_Setting.jtag_20pin_compatible);
 
+    writer.Key("webusb_popup");
+    writer.Bool(HSLink_Setting.webusb_popup);
+
     writer.Key("nickname");
     writer.String(HSLink_Setting.nickname);
 
@@ -189,6 +199,8 @@ static void parse_settings(std::string_view json)
     HSLink_Setting.led_brightness = root["led_brightness"].GetUint();
     HSLink_Setting.jtag_20pin_compatible = get_json_value(root, "jtag_20pin_compatible", false);
 
+    HSLink_Setting.webusb_popup = get_json_value(root, "webusb_popup", true);
+
     std::strncpy(HSLink_Setting.nickname, get_json_value(root, "nickname", ""), sizeof(HSLink_Setting.nickname) - 1);
     HSLink_Setting.nickname[sizeof(HSLink_Setting.nickname) - 1] = '\0';
 }
@@ -219,6 +231,8 @@ static void update_settings()
     LED_SetBrightness(HSLink_Setting.led_brightness);
     LED_SetBoost(HSLink_Setting.boost);
     LED_SetEnable(HSLink_Setting.led);
+
+    chry_dap_webusb_popup_apply();
 
     uartx_io_init();
 }

--- a/projects/HSLink-Pro/src/setting.h
+++ b/projects/HSLink-Pro/src/setting.h
@@ -37,6 +37,7 @@ typedef struct {
     bool led;
     uint8_t led_brightness;
     bool jtag_20pin_compatible;
+    bool webusb_popup;
 
     char nickname[128];
 } HSLink_Setting_t;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a setting to control whether the WebUSB landing-page popup is displayed.
  * The WebUSB popup preference is now saved, restored, and available through device settings; it is enabled by default.
  * Added support for CJTAG-specific functionality when CJTAG is enabled.

* **Bug Fixes**
  * Corrected feature detection and initialization for CJTAG-only builds.
  * Fixed CJTAG transfer and identification handling when standard JTAG support is not enabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->