### PR TITLE
fix(dap): fix cjtag macro handling for cjtag-only builds

### DIFF
--- a/DAP/Include/DAP.h
+++ b/DAP/Include/DAP.h
@@ -238,6 +238,18 @@
 #include <stdint.h>
 // #include "cmsis_compiler.h"
 
+#ifndef DAP_SWD
+#define DAP_SWD 0
+#endif
+
+#ifndef DAP_JTAG
+#define DAP_JTAG 0
+#endif
+
+#ifndef DAP_CJTAG
+#define DAP_CJTAG 0
+#endif
+
 // DAP Data structure
 typedef struct {
   uint8_t     debug_port;                       // Debug Port
@@ -258,7 +270,7 @@ typedef struct {
     uint8_t    data_phase;                      // Always generate Data Phase
   } swd_conf;
 #endif
-#if (DAP_JTAG != 0)
+#if ((DAP_JTAG != 0) || (DAP_CJTAG != 0))
   struct {                                      // JTAG Device Chain
     uint8_t   count;                            // Number of devices
     uint8_t   index;                            // Device index (device at TDO has index 0)

--- a/DAP/Include/DAP.h
+++ b/DAP/Include/DAP.h
@@ -250,6 +250,10 @@
 #define DAP_CJTAG 0
 #endif
 
+#if (((DAP_JTAG != 0) || (DAP_CJTAG != 0)) && (DAP_JTAG_DEV_CNT < 1))
+#error "DAP_JTAG_DEV_CNT must be at least 1 when JTAG or cJTAG is enabled"
+#endif
+
 // DAP Data structure
 typedef struct {
   uint8_t     debug_port;                       // Debug Port

--- a/DAP/Source/DAP.c
+++ b/DAP/Source/DAP.c
@@ -48,10 +48,6 @@
 #error "Maximum Packet Count is 255!"
 #endif
 
-#ifndef DAP_CJTAG
-#define DAP_CJTAG 0
-#endif
-
 // Clock Macros
 #define MAX_SWJ_CLOCK(delay_cycles) \
   ((CPU_CLOCK/2U) / (IO_PORT_WRITE_CYCLES + delay_cycles))
@@ -558,7 +554,7 @@ static uint32_t DAP_JTAG_Sequence(const uint8_t *request, uint8_t *response) {
   uint32_t response_count;
   uint32_t count;
 
-#if (DAP_JTAG != 0)
+#if ((DAP_JTAG != 0) || (DAP_CJTAG != 0))
   *response++ = DAP_OK;
 #else
   *response++ = DAP_ERROR;
@@ -579,7 +575,7 @@ static uint32_t DAP_JTAG_Sequence(const uint8_t *request, uint8_t *response) {
         JTAG_Sequence(sequence_info, request, response);
     }
 #endif
-#if (DAP_JTAG != 0)
+#if (DAP_CJTAG != 0)
     if (DAP_Data.debug_port == DAP_PORT_CJTAG) {
         CJTAG_Sequence(sequence_info, request, response);
     }
@@ -587,7 +583,7 @@ static uint32_t DAP_JTAG_Sequence(const uint8_t *request, uint8_t *response) {
 
     request += count;
     request_count += count + 1U;
-#if (DAP_JTAG != 0)
+#if ((DAP_JTAG != 0) || (DAP_CJTAG != 0))
     if ((sequence_info & JTAG_SEQUENCE_TDO) != 0U) {
       response += count;
       response_count += count;
@@ -606,7 +602,7 @@ static uint32_t DAP_JTAG_Sequence(const uint8_t *request, uint8_t *response) {
 //             number of bytes in request (upper 16 bits)
 static uint32_t DAP_JTAG_Configure(const uint8_t *request, uint8_t *response) {
   uint32_t count;
-#if (DAP_JTAG != 0)
+#if ((DAP_JTAG != 0) || (DAP_CJTAG != 0))
   uint32_t length;
   uint32_t bits;
   uint32_t n;
@@ -642,11 +638,20 @@ static uint32_t DAP_JTAG_Configure(const uint8_t *request, uint8_t *response) {
 //   return:   number of bytes in response (lower 16 bits)
 //             number of bytes in request (upper 16 bits)
 static uint32_t DAP_JTAG_IDCode(const uint8_t *request, uint8_t *response) {
-#if (DAP_JTAG != 0)
+#if ((DAP_JTAG != 0) || (DAP_CJTAG != 0))
   uint32_t data;
 
-  if ((DAP_Data.debug_port != DAP_PORT_JTAG) && (DAP_Data.debug_port != DAP_PORT_CJTAG)) {
-    goto id_error;
+  switch (DAP_Data.debug_port) {
+#if (DAP_JTAG != 0)
+    case DAP_PORT_JTAG:
+      break;
+#endif
+#if (DAP_CJTAG != 0)
+    case DAP_PORT_CJTAG:
+      break;
+#endif
+    default:
+      goto id_error;
   }
 
   // Device index (JTAP TAP)
@@ -664,7 +669,7 @@ static uint32_t DAP_JTAG_IDCode(const uint8_t *request, uint8_t *response) {
     data = JTAG_ReadIDCode();
   }
 #endif
-#if (DAP_JTAG != 0)
+#if (DAP_CJTAG != 0)
   if (DAP_Data.debug_port == DAP_PORT_CJTAG) {
     // Select CJTAG chain
     CJTAG_IR(JTAG_IDCODE);
@@ -1212,7 +1217,16 @@ static uint32_t DAP_JTAG_Transfer(const uint8_t *request, uint8_t *response) {
         // Select JTAG chain
         if (ir != JTAG_DPACC) {
           ir = JTAG_DPACC;
-          JTAG_IR(ir);
+#if (DAP_JTAG != 0)
+          if (DAP_Data.debug_port == DAP_PORT_JTAG) {
+            JTAG_IR(ir);
+          }
+#endif
+#if (DAP_CJTAG != 0)
+          if (DAP_Data.debug_port == DAP_PORT_CJTAG) {
+            CJTAG_IR(ir);
+          }
+#endif
         }
         // Read previous data
         retry = DAP_Data.transfer.retry_count;
@@ -1252,7 +1266,16 @@ static uint32_t DAP_JTAG_Transfer(const uint8_t *request, uint8_t *response) {
         // Select JTAG chain
         if (ir != request_ir) {
           ir = request_ir;
-          JTAG_IR(ir);
+#if (DAP_JTAG != 0)
+          if (DAP_Data.debug_port == DAP_PORT_JTAG) {
+            JTAG_IR(ir);
+          }
+#endif
+#if (DAP_CJTAG != 0)
+          if (DAP_Data.debug_port == DAP_PORT_CJTAG) {
+            CJTAG_IR(ir);
+          }
+#endif
         }
         // Write DP/AP register
         retry = DAP_Data.transfer.retry_count;
@@ -1308,7 +1331,16 @@ static uint32_t DAP_JTAG_Transfer(const uint8_t *request, uint8_t *response) {
     // Select JTAG chain
     if (ir != JTAG_DPACC) {
       ir = JTAG_DPACC;
-      JTAG_IR(ir);
+#if (DAP_JTAG != 0)
+      if (DAP_Data.debug_port == DAP_PORT_JTAG) {
+        JTAG_IR(ir);
+      }
+#endif
+#if (DAP_CJTAG != 0)
+      if (DAP_Data.debug_port == DAP_PORT_CJTAG) {
+        CJTAG_IR(ir);
+      }
+#endif
     }
     if (post_read) {
       // Read previous data
@@ -2039,7 +2071,7 @@ void DAP_Setup(void) {
   DAP_Data.swd_conf.turnaround  = 1U;
   DAP_Data.swd_conf.data_phase  = 0U;
 #endif
-#if (DAP_JTAG != 0)
+#if ((DAP_JTAG != 0) || (DAP_CJTAG != 0))
   DAP_Data.jtag_dev.count = 0U;
 #endif
 

--- a/DAP/Source/DAP.c
+++ b/DAP/Source/DAP.c
@@ -608,6 +608,10 @@ static uint32_t DAP_JTAG_Configure(const uint8_t *request, uint8_t *response) {
   uint32_t n;
 
   count = *request++;
+  if (count > DAP_JTAG_DEV_CNT) {
+    *response = DAP_ERROR;
+    return (((count + 1U) << 16) | 1U);
+  }
   DAP_Data.jtag_dev.count = (uint8_t)count;
 
   bits = 0U;

--- a/projects/HSLink-Pro/src/DAP_config.h
+++ b/projects/HSLink-Pro/src/DAP_config.h
@@ -86,6 +86,9 @@ This information includes:
 /// This information is returned by the command \ref DAP_Info as part of <b>Capabilities</b>.
 #define DAP_JTAG                1               ///< JTAG Mode: 1 = available, 0 = not available.
 
+// TODO: don't support cJTAG at this time
+#define DAP_CJTAG               0
+
 /// Configure maximum number of JTAG devices on the scan chain connected to the Debug Access Port.
 /// This setting impacts the RAM requirements of the Debug Unit. Valid range is 1 .. 255.
 #define DAP_JTAG_DEV_CNT        8U              ///< Maximum number of JTAG devices on scan chain.


### PR DESCRIPTION
- Move DAP_CJTAG default define from DAP.c to DAP.h and add DAP_SWD/DAP_JTAG defaults so all guards see a defined value
- Compile JTAG device chain struct and JTAG commands when either DAP_JTAG or DAP_CJTAG is enabled
- Route JTAG_IR/CJTAG_IR by debug_port in DAP_JTAG_Transfer and guard DAP_JTAG_IDCode cases per port
- Define DAP_CJTAG=0 for HSLink-Pro (cJTAG not supported yet)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Expanded CMSIS-DAP support for Compact JTAG (CJTAG), including sequence handling, configuration, identification, setup, and transfers.
  - Added configurable defaults for SWD, JTAG, and CJTAG interface support.
  - JTAG device-chain information is now available when either JTAG or CJTAG is enabled.

- **Bug Fixes**
  - Added validation for JTAG device-chain capacity and configuration requirements.

- **Configuration**
  - HSLink-Pro explicitly keeps CJTAG disabled because the mode is not currently supported.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->